### PR TITLE
Added Status Command

### DIFF
--- a/bin/baleen.php
+++ b/bin/baleen.php
@@ -50,6 +50,10 @@ use Baleen\Cli\Container\ServiceProvider\ConfigProvider;
 use Baleen\Cli\Container\Services;
 use League\Container\Container;
 
+if (!defined('MIGRATIONS_EXECUTABLE')) {
+    define('MIGRATIONS_EXECUTABLE', $argv[0]);
+}
+
 $container = new Container();
 $container->add(Services::BALEEN_BASE_DIR, dirname(__DIR__));
 $container->add(Services::AUTOLOADER, $composerAutoloader);

--- a/build.xml
+++ b/build.xml
@@ -15,8 +15,16 @@
             depends="prepare,lint,phploc-ci,pdepend,phpmd-ci,phpcs-ci,phpcpd-ci,phpunit-ci"
             description=""/>
 
+    <target name="build-coverage"
+            depends="prepare,lint,phploc-ci,pdepend,phpmd-ci,phpcs-ci,phpcpd-ci,phpunit-ci-coverage"
+            description=""/>
+
     <target name="build-parallel"
-            depends="prepare,lint,tools-parallel,phpunit"
+            depends="prepare,lint,tools-parallel,phpunit-ci"
+            description=""/>
+
+    <target name="build-parallel-coverage"
+            depends="prepare,lint,tools-parallel,phpunit-ci-coverage"
             description=""/>
 
     <target name="tools-parallel" description="Run tools in parallel">
@@ -185,12 +193,21 @@
             unless="phpunit-ci.done"
             depends="prepare"
             description="Run unit tests with PHPUnit">
+        <exec executable="${toolsdir}phpunit" failonerror="true" taskname="phpunit" />
+
+        <property name="phpunit-ci.done" value="true"/>
+    </target>
+
+    <target name="phpunit-ci-coverage"
+            unless="phpunit-ci-coverage.done"
+            depends="prepare"
+            description="Run unit tests with PHPUnit">
         <exec executable="${toolsdir}phpunit" failonerror="true" taskname="phpunit">
             <arg value="--coverage-clover"/>
             <arg path="${basedir}/build/logs/coverage.xml" />
         </exec>
 
-        <property name="phpunit-ci.done" value="true"/>
+        <property name="phpunit-ci-coverage.done" value="true"/>
     </target>
 
     <!--<target name="phpdox"

--- a/src/CommandBus/Config/AbstractConfigMessage.php
+++ b/src/CommandBus/Config/AbstractConfigMessage.php
@@ -1,5 +1,4 @@
 <?php
-
 /*
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
  * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
@@ -15,7 +14,7 @@
  *
  * This software consists of voluntary contributions made by many individuals
  * and is licensed under the MIT license. For more information, see
- * <https://github.com/baleen/migrations>.
+ * <http://www.doctrine-project.org>.
  */
 
 namespace Baleen\Cli\CommandBus\Config;
@@ -23,22 +22,12 @@ namespace Baleen\Cli\CommandBus\Config;
 use Baleen\Cli\CommandBus\AbstractMessage;
 use Baleen\Cli\CommandBus\Util\ConfigStorageAwareInterface;
 use Baleen\Cli\CommandBus\Util\ConfigStorageAwareTrait;
-use Symfony\Component\Console\Command\Command;
 
 /**
- * Class InitMessage.
- *
+ * Class AbstractConfigMessage
  * @author Gabriel Somoza <gabriel@strategery.io>
  */
-class InitMessage extends AbstractConfigMessage
+abstract class AbstractConfigMessage extends AbstractMessage implements ConfigStorageAwareInterface
 {
-    /**
-     * @inheritdoc
-     */
-    public static function configure(Command $command)
-    {
-        $command->setName('config:init');
-        $command->setAliases(['init']);
-        $command->setDescription('Initialises Baleen by creating a config file in the current directory.');
-    }
+    use ConfigStorageAwareTrait;
 }

--- a/src/CommandBus/Config/StatusHandler.php
+++ b/src/CommandBus/Config/StatusHandler.php
@@ -1,0 +1,193 @@
+<?php
+/*
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * This software consists of voluntary contributions made by many individuals
+ * and is licensed under the MIT license. For more information, see
+ * <http://www.doctrine-project.org>.
+ */
+
+namespace Baleen\Cli\CommandBus\Config;
+
+use Baleen\Migrations\Version;
+use Symfony\Component\Console\Output\OutputInterface;
+
+/**
+ * Class StatusHandler
+ * @author Gabriel Somoza <gabriel@strategery.io>
+ */
+class StatusHandler
+{
+    const STYLE_INFO = 'info';
+    const STYLE_COMMENT = 'comment';
+
+    /** @var OutputInterface */
+    protected $output;
+
+    /** @var StatusMessage */
+    protected $message;
+
+    /**
+     * handle
+     * @param StatusMessage $message
+     */
+    public function handle(StatusMessage $message)
+    {
+        $this->message = $message;
+        $this->output = $message->getOutput();
+        $output = $this->output;
+
+        $repository = $message->getRepository();
+        $storage = $message->getStorage();
+
+        $availableMigrations = $repository->fetchAll();
+        $migratedVersions = $storage->fetchAll();
+
+        $headVersion = $migratedVersions->last();
+
+        $currentMessage = $headVersion ?
+            "Current version: <comment>{$headVersion->getId()}</comment>" :
+            'Nothing has been migrated yet.';
+        $output->writeln($currentMessage);
+
+        $pendingCount = $availableMigrations->count() - $migratedVersions->count();
+
+        if ($pendingCount > 0) {
+            $diff = array_diff($availableMigrations->toArray(), $migratedVersions->toArray());
+            $executable = defined('MIGRATIONS_EXECUTABLE') ? MIGRATIONS_EXECUTABLE . ' ' : '';
+            $output->writeln([
+                "Your database is out-of-date by $pendingCount versions, and can be migrated.",
+                sprintf(
+                    '  (use "<comment>%smigrate</comment>" to execute all migrations)',
+                    $executable
+                ),
+                ''
+            ]);
+            if ($headVersion) {
+                list($beforeHead, $afterHead) = $this->splitDiff($diff, $message->getComparator(), $headVersion);
+            } else {
+                $beforeHead = [];
+                $afterHead = $diff;
+            }
+            $this->printDiff(
+                $beforeHead,
+                [
+                    'Old migrations still pending:',
+                    sprintf("  (use \"<comment>{$executable}migrate HEAD</comment>\" to migrate them)", $executable),
+                ],
+                self::STYLE_COMMENT
+            );
+            $this->printDiff($afterHead, ['New migrations:'], self::STYLE_INFO);
+        } else {
+            $output->writeln('Your database is up-to-date.');
+        }
+    }
+
+    /**
+     * printPendingVersion
+     * @param $version
+     * @param $style
+     */
+    protected function printPendingVersion($version, $style)
+    {
+        /** @var Version $version */
+        $id = $version->getId();
+        $reflectionClass = new \ReflectionClass($version->getMigration());
+        $absolutePath = $reflectionClass->getFileName();
+        $fileName = $absolutePath ? $this->getRelativePath(getcwd(), $absolutePath) : '';
+        $this->output->writeln("\t<$style>[$id] $fileName</$style>");
+    }
+
+    /**
+     * getRelativePath
+     * @param $from
+     * @param $to
+     * @return string
+     * @link http://stackoverflow.com/questions/2637945/getting-relative-path-from-absolute-path-in-php
+     */
+    protected function getRelativePath($from, $to)
+    {
+        // some compatibility fixes for Windows paths
+        $from = is_dir($from) ? rtrim($from, '\/') . '/' : $from;
+        $to = is_dir($to) ? rtrim($to, '\/') . '/' : $to;
+        $from = str_replace('\\', '/', $from);
+        $to = str_replace('\\', '/', $to);
+
+        $from = explode('/', $from);
+        $to = explode('/', $to);
+        $relPath = $to;
+
+        foreach ($from as $depth => $dir) {
+            // find first non-matching dir
+            if (isset($to[$depth]) && $dir === $to[$depth]) {
+                // ignore this directory
+                array_shift($relPath);
+            } else {
+                // get number of remaining dirs to $from
+                $remaining = count($from) - $depth;
+                if ($remaining > 1) {
+                    // add traversals up to first matching dir
+                    $padLength = (count($relPath) + $remaining - 1) * -1;
+                    $relPath = array_pad($relPath, $padLength, '..');
+                    break;
+                }
+            }
+        }
+        return implode('/', $relPath);
+    }
+
+    /**
+     * printDiff
+     * @param array $versions
+     * @param $message
+     * @param $style
+     */
+    protected function printDiff(array $versions, $message, $style = self::STYLE_INFO)
+    {
+        $first = true;
+        foreach ($versions as $version) {
+            if ($first) {
+                $this->output->writeln($message);
+                $this->output->writeln('');
+                $first = false;
+            }
+            $this->printPendingVersion($version, $style);
+        }
+        if (!$first) {
+            // if there was at least one version in the array
+            $this->output->writeln('');
+        }
+    }
+
+    /**
+     * splitDiff
+     * @param array $diff
+     * @param callable $comparator
+     * @param Version $head
+     * @return array
+     */
+    protected function splitDiff(array $diff, callable $comparator, Version $head)
+    {
+        $beforeHead = [];
+        $afterHead = [];
+        foreach ($diff as $v) {
+            $result = $comparator($v, $head);
+            if ($result < 0) {
+                $beforeHead[] = $v;
+            } elseif ($result > 0) {
+                $afterHead[] = $v;
+            }
+        }
+        return [$beforeHead, $afterHead];
+    }
+}

--- a/src/CommandBus/Config/StatusMessage.php
+++ b/src/CommandBus/Config/StatusMessage.php
@@ -1,5 +1,4 @@
 <?php
-
 /*
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
  * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
@@ -15,30 +14,41 @@
  *
  * This software consists of voluntary contributions made by many individuals
  * and is licensed under the MIT license. For more information, see
- * <https://github.com/baleen/migrations>.
+ * <http://www.doctrine-project.org>.
  */
 
 namespace Baleen\Cli\CommandBus\Config;
 
-use Baleen\Cli\CommandBus\AbstractMessage;
-use Baleen\Cli\CommandBus\Util\ConfigStorageAwareInterface;
-use Baleen\Cli\CommandBus\Util\ConfigStorageAwareTrait;
+use Baleen\Cli\CommandBus\Util\ComparatorAwareInterface;
+use Baleen\Cli\CommandBus\Util\ComparatorAwareTrait;
+use Baleen\Cli\CommandBus\Util\RepositoryAwareInterface;
+use Baleen\Cli\CommandBus\Util\RepositoryAwareTrait;
+use Baleen\Cli\CommandBus\Util\StorageAwareInterface;
+use Baleen\Cli\CommandBus\Util\StorageAwareTrait;
 use Symfony\Component\Console\Command\Command;
 
 /**
- * Class InitMessage.
- *
+ * Class StatusMessage
  * @author Gabriel Somoza <gabriel@strategery.io>
  */
-class InitMessage extends AbstractConfigMessage
+class StatusMessage extends AbstractConfigMessage implements
+    RepositoryAwareInterface,
+    StorageAwareInterface,
+    ComparatorAwareInterface
 {
+    use RepositoryAwareTrait;
+    use StorageAwareTrait;
+    use ComparatorAwareTrait;
+
     /**
-     * @inheritdoc
+     * Configures a console command by setting name, description, arguments, etc.
+     *
+     * @param Command $command
      */
     public static function configure(Command $command)
     {
-        $command->setName('config:init');
-        $command->setAliases(['init']);
-        $command->setDescription('Initialises Baleen by creating a config file in the current directory.');
+        $command->setName('config:status');
+        $command->setAliases(['status']);
+        $command->setDescription('Shows the current migration status.');
     }
 }

--- a/src/CommandBus/Repository/CreateHandler.php
+++ b/src/CommandBus/Repository/CreateHandler.php
@@ -90,7 +90,9 @@ class CreateHandler
             ));
             if ($editorCmd) {
                 $pipes = [];
-                proc_open($editorCmd.' '.escapeshellarg($result), array(), $pipes);
+                $baseDir = dirname($config->getMigrationsDirectoryPath());
+                $command = $editorCmd . ' ' . escapeshellarg($baseDir . DIRECTORY_SEPARATOR . $result);
+                proc_open($command, array(), $pipes);
             }
         } else {
             $output->writeln(

--- a/src/Container/ServiceProvider/CommandsProvider.php
+++ b/src/Container/ServiceProvider/CommandsProvider.php
@@ -23,6 +23,8 @@ namespace Baleen\Cli\Container\ServiceProvider;
 use Baleen\Cli\BaseCommand;
 use Baleen\Cli\CommandBus\Config\InitMessage;
 use Baleen\Cli\CommandBus\Config\InitHandler;
+use Baleen\Cli\CommandBus\Config\StatusHandler;
+use Baleen\Cli\CommandBus\Config\StatusMessage;
 use Baleen\Cli\CommandBus\Factory\DefaultFactory;
 use Baleen\Cli\CommandBus\Factory\MessageFactoryInterface;
 use Baleen\Cli\CommandBus\Repository\CreateMessage;
@@ -61,6 +63,10 @@ class CommandsProvider extends ServiceProvider
         Services::CMD_CONFIG_INIT => [
             'class' => InitMessage::class,
             'handler' => InitHandler::class,
+        ],
+        Services::CMD_CONFIG_STATUS => [
+            'class' => StatusMessage::class,
+            'handler' => StatusHandler::class,
         ],
         Services::CMD_REPOSITORY_CREATE => [
             'class' => CreateMessage::class,

--- a/src/Container/Services.php
+++ b/src/Container/Services.php
@@ -37,6 +37,7 @@ interface Services
     const COMMAND_BUS = 'commands.bus';
     const COMMANDS = 'commands';
     const CMD_CONFIG_INIT = 'commands.config.init';
+    const CMD_CONFIG_STATUS = 'commands.config.status';
     const CMD_TIMELINE_EXECUTE = 'commands.timeline.execute';
     const CMD_TIMELINE_MIGRATE = 'commands.timeline.migrate';
     const CMD_REPOSITORY_CREATE = 'commands.repository.create';

--- a/test/CommandBus/Config/InitMessageTest.php
+++ b/test/CommandBus/Config/InitMessageTest.php
@@ -19,9 +19,8 @@
 
 namespace BaleenTest\Cli\CommandBus\Config;
 
-use Baleen\Cli\CommandBus\AbstractMessage;
+use Baleen\Cli\CommandBus\Config\AbstractConfigMessage;
 use Baleen\Cli\CommandBus\Config\InitMessage;
-use Baleen\Cli\CommandBus\Util\ConfigStorageAwareInterface;
 use Baleen\Cli\Config\ConfigStorage;
 use BaleenTest\Cli\CommandBus\MessageTestCase;
 use Mockery as m;
@@ -38,8 +37,7 @@ class InitMessageTest extends MessageTestCase
     public function testConstructor()
     {
         $instance = new InitMessage();
-        $this->assertInstanceOf(AbstractMessage::class, $instance);
-        $this->assertInstanceOf(ConfigStorageAwareInterface::class, $instance);
+        $this->assertInstanceOf(AbstractConfigMessage::class, $instance);
     }
 
     /**
@@ -74,7 +72,7 @@ class InitMessageTest extends MessageTestCase
     /**
      * @inheritdoc
      */
-    protected function getCommandClass()
+    protected function getClassName()
     {
         return InitMessage::class;
     }

--- a/test/CommandBus/Config/StatusHandlerTest.php
+++ b/test/CommandBus/Config/StatusHandlerTest.php
@@ -1,0 +1,308 @@
+<?php
+/*
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * This software consists of voluntary contributions made by many individuals
+ * and is licensed under the MIT license. For more information, see
+ * <http://www.doctrine-project.org>.
+ */
+
+namespace BaleenTest\Baleen\CommandBus\Config;
+
+use Baleen\Cli\CommandBus\Config\StatusHandler;
+use Baleen\Cli\CommandBus\Config\StatusMessage;
+use Baleen\Cli\Config\ConfigStorage;
+use Baleen\Migrations\Migration\MigrationInterface;
+use Baleen\Migrations\Repository\RepositoryInterface;
+use Baleen\Migrations\Storage\StorageInterface;
+use Baleen\Migrations\Version as V;
+use Baleen\Migrations\Version;
+use Baleen\Migrations\Version\Collection\LinkedVersions;
+use Baleen\Migrations\Version\Collection\MigratedVersions;
+use Baleen\Migrations\Version\Comparator\DefaultComparator;
+use BaleenTest\Cli\CommandBus\HandlerTestCase;
+use Mockery as m;
+
+/**
+ * Class StatusHandlerTest
+ * @author Gabriel Somoza <gabriel@strategery.io>
+ *
+ * @property StatusMessage|m\Mock command
+ */
+class StatusHandlerTest extends HandlerTestCase
+{
+    /** @var m\Mock|ConfigStorage */
+    protected $configStorage;
+
+    /** @var m\Mock|RepositoryInterface */
+    protected $repository;
+
+    /** @var m\Mock|StorageInterface */
+    protected $storage;
+
+    /** @var m\Mock|callable */
+    protected $comparator;
+
+    /** @var m\Mock */
+    protected $comparatorExpectation;
+
+    /**
+     * setUp
+     */
+    public function setUp()
+    {
+        $this->instance = m::mock(StatusHandler::class)
+            ->shouldAllowMockingProtectedMethods()
+            ->makePartial();
+        $this->command = m::mock(StatusMessage::class)->makePartial();
+        $this->configStorage = m::mock(ConfigStorage::class);
+        $this->command->setConfigStorage($this->configStorage);
+        $this->repository = m::mock(RepositoryInterface::class);
+        $this->command->setRepository($this->repository);
+        $this->storage = m::mock(StorageInterface::class);
+        $this->command->setStorage($this->storage);
+        $this->command->setComparator(new DefaultComparator());
+
+        parent::setUp();
+    }
+
+    /**
+     * testPrintPendingVersions
+     * @param $id
+     * @param $migrationClass
+     * @param $style
+     * @dataProvider printPendingVersionProvider
+     */
+    public function testPrintPendingVersion($id, $migrationClass, $style)
+    {
+        $version = m::mock(V::class);
+        $version->shouldReceive([
+            'getId' => $id,
+            'getMigration' => $migrationClass,
+        ])->once();
+        if ($migrationClass === '__INVALID__') {
+            $this->setExpectedException(\ReflectionException::class);
+        } else {
+            $this->setPropVal('output', $this->output, $this->instance);
+            $this->output->shouldReceive('writeln')->once()->with("/^.*?\\<$style\\>.*?$id.*?\\<\\/$style\\>.*?$/");
+        }
+        $this->invokeMethod('printPendingVersion', $this->instance, [$version, $style]);
+    }
+
+    /**
+     * printPendingVersionsProvider
+     * @return array
+     */
+    public function printPendingVersionProvider()
+    {
+        $ids = [123];
+        $migrationClasses = ['stdClass', '__INVALID__'];
+        $styles = [StatusHandler::STYLE_COMMENT, StatusHandler::STYLE_INFO];
+        return $this->combinations([$ids, $migrationClasses, $styles]);
+    }
+
+    /**
+     * testPrintDiff
+     * @param $versions
+     * @param $message
+     * @param $style
+     * @dataProvider printDiffProvider
+     */
+    public function testPrintDiff(array $versions, $message, $style)
+    {
+        if (count($versions)) {
+            $this->instance
+                ->shouldReceive('printPendingVersion')
+                ->times(count($versions))
+                ->with(m::type(V::class), $style);
+            $this->output->shouldReceive('writeln')->once()->with($message);
+            $this->output->shouldReceive('writeln')->twice()->with('');
+        } else {
+            $this->output->shouldNotReceive('writeln');
+        }
+        $this->setPropVal('output', $this->output, $this->instance);
+        $this->invokeMethod('printDiff', $this->instance, [$versions, $message, $style]);
+    }
+
+    /**
+     * printDiffProvider
+     * @return array
+     */
+    public function printDiffProvider()
+    {
+        $versions = [[], [m::mock(V::class), m::mock(V::class)]];
+        $messages = ['Single Message', ['Multiple', 'Messages']];
+        $styles = [StatusHandler::STYLE_INFO, StatusHandler::STYLE_COMMENT];
+        return $this->combinations([$versions, $messages, $styles]);
+    }
+
+    /**
+     * testSplitDiff
+     * @param V[] $diff
+     * @param callable $comparator
+     * @param V $head
+     * @dataProvider splitDiffProvider
+     */
+    public function testSplitDiff(array $diff, callable $comparator, V $head)
+    {
+        list($beforeHead, $afterHead) = $this->invokeMethod('splitDiff', $this->instance, [$diff, $comparator, $head]);
+        if (empty($diff)) {
+            $this->assertEmpty($beforeHead);
+            $this->assertEmpty($afterHead);
+        }
+        foreach ($beforeHead as $v) {
+            $this->assertLessThan(0, $comparator($v, $head));
+        }
+        foreach ($afterHead as $v) {
+            $this->assertGreaterThan(0, $comparator($v, $head));
+        }
+    }
+
+    /**
+     * splitDiffProvider
+     * @return array
+     */
+    public function splitDiffProvider()
+    {
+        $defaultComparator = new DefaultComparator();
+        $diffs = [[], V::fromArray(range(2, 10))];
+        $comparators = [$defaultComparator];
+        $heads = V::fromArray(1, 2, 5, 10, 11);
+        return $this->combinations([$diffs, $comparators, $heads]);
+    }
+
+    /**
+     * testHandle
+     * @param LinkedVersions $available
+     * @param MigratedVersions $migrated
+     * @dataProvider handleProvider
+     */
+    public function testHandle(LinkedVersions $available, MigratedVersions $migrated)
+    {
+        $this->repository->shouldReceive('fetchAll')->once()->andReturn($available);
+        $this->storage->shouldReceive('fetchAll')->once()->andReturn($migrated);
+        $this->command->setRepository($this->repository);
+        $this->command->setStorage($this->storage);
+        $currentMsg = $migrated->last() === false ?
+            '/[Nn]othing has been migrated/' :
+            '/[Cc]urrent version.*?' . $migrated->last()->getId() . '.*?$/';
+        $this->output->shouldReceive('writeln')->once()->with($currentMsg);
+        $pendingCount = $available->count() - $migrated->count();
+        if ($pendingCount > 0) {
+            $this->output->shouldReceive('writeln')->with(m::on(function($messages) use ($pendingCount) {
+                return preg_match("/out\\-of\\-date.*?by $pendingCount versions/", $messages[0])
+                    && is_string($messages[1])
+                    && $messages[2] === '';
+            }))->once();
+            $this->instance->shouldReceive('printDiff')->with(
+                m::type('array'),
+                m::on(function($messages) {
+                    return preg_match('/still pending.*?:$/', $messages[0])
+                        && preg_match('/use.*?migrate.*?to migrate them/', $messages[1]);
+                }),
+                StatusHandler::STYLE_COMMENT
+            )->once();
+            $this->instance->shouldReceive('printDiff')->with(
+                m::type('array'),
+                m::on(function($messages) {
+                    return (bool) preg_match('/[Nn]ew migrations:$/', $messages[0]);
+                }),
+                StatusHandler::STYLE_INFO
+            )->once();
+        } else {
+            $this->output->shouldReceive('writeln')->with('/up\\-to\\-date/')->once();
+        }
+        $this->handle();
+    }
+
+    /**
+     * handleProvider
+     * @return array
+     */
+    public function handleProvider()
+    {
+        $repVersions = [
+            [],
+            Version::fromArray(range(1,10))
+        ];
+        $repositories = [];
+        foreach ($repVersions as $versions) {
+            $this->linkVersions($versions);
+            $repositories[] = new LinkedVersions($versions);
+        }
+        $storageVersions = [
+            [],
+            Version::fromArray(range(1,3)),
+        ];
+        $storages = [];
+        foreach ($storageVersions as $versions) {
+            $this->linkVersions($versions, true);
+            $storages[] = new MigratedVersions($versions);
+        }
+        return $this->combinations([$repositories, $storages]);
+    }
+
+    /**
+     * linkVersions
+     * @param $versions
+     * @param bool $migrated
+     */
+    protected function linkVersions(&$versions, $migrated = false)
+    {
+        foreach ($versions as $v) {
+            /** @var Version $v */
+            /** @var MigrationInterface|m\Mock $migration */
+            $migration = m::mock(MigrationInterface::class);
+            $v->setMigration($migration);
+            $v->setMigrated($migrated);
+        }
+    }
+
+    /**
+     * testGetRelativePath
+     * @param $from
+     * @param $to
+     * @param $expected
+     * @dataProvider getRelativePathProvider
+     */
+    public function testGetRelativePath($from, $to, $expected)
+    {
+        $result = $this->invokeMethod('getRelativePath', $this->instance, [$from, $to]);
+        $this->assertEquals($expected, $result);
+    }
+
+    /**
+     * getRelativePathProvider
+     * @return array
+     */
+    public function getRelativePathProvider()
+    {
+        $file1 = '/var/log/http/access.log';
+        $file2 = '/etc/apache/config.d/httpd.conf';
+        $file3 = '/var/log/http/website/error.log';
+        $dir1 = '/var';
+        return [
+            ['', '', ''],                           // empty
+            ['/', '/', ''],                         // from root to root
+            ['/var', '/var', ''],                   // from directory to directory
+            ['/var/log.php', '/var/log.php', ''],   // from file to file
+            ['/', '/var/log.php', 'var/log.php'],   // from root to file
+            ['', '/var/log.php', 'var/log.php'],    // without $from (same as from root)
+            ['/var', '', '..'],                     // towards root
+            ['/var', '', '..'],                     // without $to (same as towards root)
+            [$file1, $file2, '../../..' . $file2],  // backwards traversal
+            [$file1, $file3, 'website/error.log'],  // inward traversal
+            [$dir1, $file1, 'log/http/access.log'], // inward traversal from directory
+        ];
+    }
+}

--- a/test/CommandBus/Config/StatusMessageTest.php
+++ b/test/CommandBus/Config/StatusMessageTest.php
@@ -17,23 +17,21 @@
  * <http://www.doctrine-project.org>.
  */
 
-namespace BaleenTest\Cli\CommandBus\Timeline;
+namespace BaleenTest\Baleen\CommandBus\Config;
 
-use Baleen\Cli\CommandBus\Timeline\AbstractTimelineCommand;
-use Baleen\Cli\CommandBus\Timeline\ExecuteMessage;
-use Baleen\Migrations\Migration\Options;
-use Baleen\Migrations\Timeline;
-use Baleen\Migrations\Version;
+use Baleen\Cli\CommandBus\Config\AbstractConfigMessage;
+use Baleen\Cli\CommandBus\Config\StatusMessage;
+use Baleen\Cli\CommandBus\Util\ComparatorAwareInterface;
+use Baleen\Cli\CommandBus\Util\RepositoryAwareInterface;
+use Baleen\Cli\CommandBus\Util\StorageAwareInterface;
 use BaleenTest\Cli\CommandBus\MessageTestCase;
 use Mockery as m;
-use Symfony\Component\Console\Input\InputArgument;
-use Symfony\Component\Console\Input\InputOption;
 
 /**
- * Class ExecuteMessageTest
+ * Class StatusMessageTest
  * @author Gabriel Somoza <gabriel@strategery.io>
  */
-class ExecuteMessageTest extends MessageTestCase
+class StatusMessageTest extends MessageTestCase
 {
 
     /**
@@ -41,8 +39,16 @@ class ExecuteMessageTest extends MessageTestCase
      */
     public function testConstructor()
     {
-        $instance = new ExecuteMessage();
-        $this->assertInstanceOf(AbstractTimelineCommand::class, $instance);
+        $instance = new StatusMessage();
+        $list = [
+            AbstractConfigMessage::class,
+            RepositoryAwareInterface::class,
+            StorageAwareInterface::class,
+            ComparatorAwareInterface::class,
+        ];
+        foreach ($list as $expected) {
+            $this->assertInstanceOf($expected, $instance);
+        }
     }
 
     /**
@@ -51,7 +57,7 @@ class ExecuteMessageTest extends MessageTestCase
      */
     protected function getClassName()
     {
-        return ExecuteMessage::class;
+        return StatusMessage::class;
     }
 
     /**
@@ -69,32 +75,18 @@ class ExecuteMessageTest extends MessageTestCase
     protected function getExpectations()
     {
         return [
-            [   'name' => 'setName',
-                'with' => 'timeline:execute',
+            [
+                'name' => 'setName',
+                'with' => 'config:status',
             ],
-            [   'name' => 'setAliases',
-                'with' => [['exec']],
+            [
+                'name' => 'setAliases',
+                'with' => [['status']],
             ],
-            [   'name' => 'setDescription',
+            [
+                'name' => 'setDescription',
                 'with' => m::type('string'),
-            ],
-            [   'name' => 'addOption',
-                'with' => [ExecuteMessage::OPT_DRY_RUN, 'd', InputOption::VALUE_NONE, m::type('string')],
-            ],
-            [   'name' => 'addOption',
-                'with' => [ExecuteMessage::OPT_NO_STORAGE, m::any(), InputOption::VALUE_NONE, m::type('string')],
-            ],
-            [   'name' => 'addArgument',
-                'with' => [ExecuteMessage::ARG_VERSION, InputArgument::REQUIRED, m::type('string')],
-            ],
-            [   'name' => 'addArgument',
-                'with' => [
-                    ExecuteMessage::ARG_DIRECTION,
-                    InputArgument::OPTIONAL,
-                    m::type('string'),
-                    Options::DIRECTION_UP,
-                ],
-            ],
+            ]
         ];
     }
 }

--- a/test/CommandBus/MessageTestCase.php
+++ b/test/CommandBus/MessageTestCase.php
@@ -69,7 +69,7 @@ abstract class MessageTestCase extends BaseTestCase
                     break;
             }
         }
-        forward_static_call([$this->getCommandClass(), 'configure'], $command);
+        forward_static_call([$this->getClassName(), 'configure'], $command);
     }
 
     /**
@@ -78,10 +78,10 @@ abstract class MessageTestCase extends BaseTestCase
     abstract public function testConstructor();
 
     /**
-     * getCommandClass must return a string with the FQN of the command class being tested
+     * getClassName must return a string with the FQN of the command class being tested
      * @return string
      */
-    abstract protected function getCommandClass();
+    abstract protected function getClassName();
 
     /**
      * Must return an array in the format:

--- a/test/CommandBus/Repository/CreateHandlerTest.php
+++ b/test/CommandBus/Repository/CreateHandlerTest.php
@@ -155,6 +155,9 @@ class CreateHandlerTest extends HandlerTestCase
 
         $config = m::mock(Config::class);
         $config->shouldReceive(['getMigrationsDirectory' => $migrationsDirectory])->once();
+        if ($editorCmd) {
+            $config->shouldReceive('getMigrationsDirectoryPath')->once()->andReturn($migrationsDirectory);
+        }
         $this->command->shouldReceive('getConfig')->once()->andReturn($config);
 
         $argumentNamespace = key($namespace) ?: null;
@@ -207,13 +210,13 @@ class CreateHandlerTest extends HandlerTestCase
             [ // simple test
                 ['SimpleTitle' => 'SimpleTitle'],
                 ['SimpleNamespace' => 'SimpleNamespace'],
-                true,
+                true, // success
             ],
             [ // simple test with editor cmd
                 ['SimpleTitle' => 'SimpleTitle'],
                 ['SimpleNamespace' => 'SimpleNamespace'],
                 true,
-                'which' // FIXME: it would be better to test this gets called
+                'which' // FIXME: it would be better to test whether this gets called
             ],
             [ // test null namespace (load from config)
                 ['SimpleTitle' => 'SimpleTitle'],

--- a/test/CommandBus/Repository/CreateMessageTest.php
+++ b/test/CommandBus/Repository/CreateMessageTest.php
@@ -32,10 +32,10 @@ use Symfony\Component\Console\Input\InputOption;
 class CreateMessageTest extends MessageTestCase
 {
     /**
-     * getCommandClass must return a string with the FQN of the command class being tested
+     * getClassName must return a string with the FQN of the command class being tested
      * @return string
      */
-    protected function getCommandClass()
+    protected function getClassName()
     {
         return CreateMessage::class;
     }

--- a/test/CommandBus/Repository/LatestMessageTest.php
+++ b/test/CommandBus/Repository/LatestMessageTest.php
@@ -42,10 +42,10 @@ class LatestMessageTest extends MessageTestCase
     }
 
     /**
-     * getCommandClass must return a string with the FQN of the command class being tested
+     * getClassName must return a string with the FQN of the command class being tested
      * @return string
      */
-    protected function getCommandClass()
+    protected function getClassName()
     {
         return LatestMessage::class;
     }

--- a/test/CommandBus/Repository/ListMessageTest.php
+++ b/test/CommandBus/Repository/ListMessageTest.php
@@ -42,10 +42,10 @@ class ListMessageTest extends MessageTestCase
     }
 
     /**
-     * getCommandClass must return a string with the FQN of the command class being tested
+     * getClassName must return a string with the FQN of the command class being tested
      * @return string
      */
-    protected function getCommandClass()
+    protected function getClassName()
     {
         return ListMessage::class;
     }

--- a/test/CommandBus/Storage/LatestMessageTest.php
+++ b/test/CommandBus/Storage/LatestMessageTest.php
@@ -40,10 +40,10 @@ class LatestMessageTest extends MessageTestCase
     }
 
     /**
-     * getCommandClass must return a string with the FQN of the command class being tested
+     * getClassName must return a string with the FQN of the command class being tested
      * @return string
      */
-    protected function getCommandClass()
+    protected function getClassName()
     {
         return LatestMessage::class;
     }

--- a/test/CommandBus/Timeline/MigrateMessageTest.php
+++ b/test/CommandBus/Timeline/MigrateMessageTest.php
@@ -44,10 +44,10 @@ class MigrateMessageTest extends MessageTestCase
     }
 
     /**
-     * getCommandClass must return a string with the FQN of the command class being tested
+     * getClassName must return a string with the FQN of the command class being tested
      * @return string
      */
-    protected function getCommandClass()
+    protected function getClassName()
     {
         return MigrateMessage::class;
     }


### PR DESCRIPTION
### Added
- `config:status` command (alias: `status`).

### Changes
- Make Ant build without coverage by default.

### Fixed
- Fix `--editor-cmd` functionality for the `migrations:create` command.