### PR TITLE
Update Migrations

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
     "require": {
         "symfony/console": "^2.7",
         "psr/log": "^1.0",
-        "baleen/migrations": "^0.6",
+        "baleen/migrations": "^0.7",
         "symfony/yaml": "^2.7",
         "symfony/config": "^2.7",
         "league/container": "^1.3",

--- a/src/CommandBus/Config/StatusHandler.php
+++ b/src/CommandBus/Config/StatusHandler.php
@@ -53,6 +53,7 @@ class StatusHandler
         $availableMigrations = $repository->fetchAll();
         $migratedVersions = $storage->fetchAll();
 
+        $migratedVersions->sortWith($message->getComparator());
         $headVersion = $migratedVersions->last();
 
         $currentMessage = $headVersion ?

--- a/src/CommandBus/Timeline/ExecuteHandler.php
+++ b/src/CommandBus/Timeline/ExecuteHandler.php
@@ -35,7 +35,7 @@ class ExecuteHandler
     {
         $input = $command->getInput();
         $output = $command->getOutput();
-        $version = new Version($input->getArgument(ExecuteMessage::ARG_VERSION));
+        $version = (string) $input->getArgument(ExecuteMessage::ARG_VERSION);
 
         $direction = $input->getArgument(ExecuteMessage::ARG_DIRECTION) == Options::DIRECTION_DOWN ?
             Options::DIRECTION_DOWN :
@@ -60,7 +60,7 @@ class ExecuteHandler
                 $version = $result;
                 $command->getStorage()->update($version);
             }
-            $output->writeln("Version <info>{$version->getId()}</info> migrated <info>$direction</info> successfully.");
+            $output->writeln("Version <info>$version</info> migrated <info>$direction</info> successfully.");
         }
     }
 }

--- a/src/CommandBus/Timeline/ExecuteMessage.php
+++ b/src/CommandBus/Timeline/ExecuteMessage.php
@@ -33,7 +33,8 @@ use Symfony\Component\Console\Input\InputArgument;
 class ExecuteMessage extends AbstractTimelineCommand
 {
     const COMMAND_NAME = 'execute';
-    const COMMAND_ALIAS = 'exec';
+    const COMMAND_ALIAS_SHORT = 'exec';
+    const COMMAND_ALIAS = 'execute';
     const ARG_VERSION = 'version';
     const ARG_DIRECTION = 'direction';
 
@@ -44,7 +45,7 @@ class ExecuteMessage extends AbstractTimelineCommand
     {
         parent::configure($command);
         $command->setName('timeline:execute')
-            ->setAliases(['exec'])
+            ->setAliases([self::COMMAND_ALIAS_SHORT, self::COMMAND_ALIAS])
             ->setDescription('Execute a single migration version up or down manually.')
             ->addArgument(self::ARG_VERSION, InputArgument::REQUIRED, 'The version to execute.')
             ->addArgument(

--- a/src/CommandBus/Timeline/MigrateHandler.php
+++ b/src/CommandBus/Timeline/MigrateHandler.php
@@ -72,8 +72,8 @@ class MigrateHandler
         $output = $command->getOutput();
         $this->command = $command;
 
-        $targetArg = $input->getArgument(MigrateMessage::ARG_TARGET);
-        $strategy = $this->getStrategyOption($input);
+        $targetArg = (string) $input->getArgument(MigrateMessage::ARG_TARGET);
+        $strategy = (string) $this->getStrategyOption($input);
 
         $options = new Options(Options::DIRECTION_UP); // this value will get replaced by timeline later
         $options->setDryRun($input->getOption(MigrateMessage::OPT_DRY_RUN));

--- a/test/CommandBus/Timeline/ExecuteHandlerTest.php
+++ b/test/CommandBus/Timeline/ExecuteHandlerTest.php
@@ -69,8 +69,8 @@ class ExecuteHandlerTest extends HandlerTestCase
 
         if (!$isInteractive || $askResult) {
             $timeline->shouldReceive('runSingle')->with(
-                m::on(function (Version $version) {
-                    return $version->getId() === '123';
+                m::on(function ($version) {
+                    return (string) $version === '123';
                 }),
                 m::on(function (Options $options) use ($isUp, $isDryRun) {
                     return $options->isDryRun() === $isDryRun

--- a/test/CommandBus/Timeline/ExecuteMessageTest.php
+++ b/test/CommandBus/Timeline/ExecuteMessageTest.php
@@ -73,7 +73,7 @@ class ExecuteMessageTest extends MessageTestCase
                 'with' => 'timeline:execute',
             ],
             [   'name' => 'setAliases',
-                'with' => [['exec']],
+                'with' => [['exec', 'execute']],
             ],
             [   'name' => 'setDescription',
                 'with' => m::type('string'),


### PR DESCRIPTION
Update to incorporate changes from Baleen Migrations 0.7.

### Changes
- Updated to Baleen Migrations 0.7.

### Fixed
- Storage collections don't get sorted in `config:status` command.